### PR TITLE
fix: added mobile header

### DIFF
--- a/components/Challenge/PayforCreate.tsx
+++ b/components/Challenge/PayforCreate.tsx
@@ -22,15 +22,18 @@ export default function PayforCreate() {
   const isHeroCreated = heroes.length > 0;
 
   const TRIGGER = (
-    <Button variant="simple" className="text-white gap-3">
-      Create Challenge
+    <Button variant="simple" className="pt-3.5 text-sm md:text-base text-yellow-400 md:text-white flex flex-row items-center justify-end w-full md:w-auto">
+      <div className="flex">
+      <span className="block md:hidden">New Challenge</span>
+      <span className="hidden md:block">Create New Challenge</span>
       <Image
         src="/plus.svg"
         alt=""
         width={1000}
         height={1000}
-        className="w-[24px] h-[24px] "
+        className="w-4 h-4 md:w-6 md:h-6"
       />
+      </div>
     </Button>
   );
 

--- a/components/Challenge/StageBar.tsx
+++ b/components/Challenge/StageBar.tsx
@@ -10,24 +10,22 @@ export default function StageBar({
   title: string;
 }) {
   return (
-    <div className="flex flex-col md:flex-row md:px-12 mx-auto gap-4 md:gap-0 bg-arena-bg border-b-[0.1px] border-white/20 rounded-lg shadow-padentro mt-12 max-w-screen-2xl min-h-[110px] p-4 md:p-0 items-center">
-      <div className="flex items-center gap-4 justify-center w-full md:w-auto md:justify-start flex-1">
+    <div className="flex md:items-center max-w-screen-2xl md:ml-16 mx-4 mt-8 py-3 md:p-4 bg-arena-bg border-b border-white/20 rounded-lg shadow-padentro">
+      <div className="flex items-center gap-3 flex-1">
         <Image
           src={image}
           alt=""
           width={1000}
           height={1000}
-          className="w-[62px] h-[62px] min-w-[62px]"
+          className="w-12 h-12 md:w-16 md:h-16"
         />
-        <p className="text-4xl md:text-5xl text-white break-words">{title}</p>
+        <h1 className="-mx-4 text-lg md:text-4xl text-white">{title}</h1>
       </div>
+
       {action && (
-        <>
-          <div className="w-full h-[1px] bg-white/20 md:hidden" />
-          <div className="flex items-center justify-center w-full md:w-auto">
+          <div className="md:mt-0 w-full md:w-auto">
             {action}
           </div>
-        </>
       )}
     </div>
   );

--- a/components/Character/NoAddress.tsx
+++ b/components/Character/NoAddress.tsx
@@ -13,7 +13,7 @@ export default function NoAddress({
   const { address } = useAccount();
 
   return (
-    <div className="bg-arena-bg bg-cover p-4 sm:p-8 border border-b mx-4 sm:m-8 border-white/20 rounded-lg sm:max-w-6xl w-full w-[calc(100%-2rem)] shadow-padentro mb-2 mt-4">
+    <div className="bg-arena-bg bg-cover p-4 sm:p-8 border border-b mx-auto sm:m-8 border-white/20 rounded-lg sm:max-w-6xl w-[calc(100%-2rem)] shadow-padentro mb-2 mt-4">
       <div className="mx-10 my-10 sm:m-16 flex items-center justify-center flex-col">
         <Image
           src="/woodensword.svg"

--- a/components/Character/Stage.tsx
+++ b/components/Character/Stage.tsx
@@ -23,15 +23,18 @@ export default function Stage() {
         action={
           <CreateNew
             trigger={
-              <Button variant="simple" className="text-white gap-3">
-                Create New Character
+              <Button variant="simple" className="pt-3.5 text-sm md:text-base text-yellow-400 md:text-white flex flex-row items-center justify-end w-full md:w-auto">
+                <div className="flex">
+                <span className="block md:hidden">New Character</span>
+                <span className="hidden md:block">Create New Character</span>
                 <Image
                   src="/plus.svg"
                   alt=""
                   width={1000}
                   height={1000}
-                  className="w-[24px] h-[24px] "
+                  className="w-4 h-4 md:w-6 md:h-6"
                 />
+                </div>
               </Button>
             }
           />

--- a/components/ui/button-create-challenge.tsx
+++ b/components/ui/button-create-challenge.tsx
@@ -8,7 +8,6 @@ import {
   AlertDialogTrigger,
   AlertDialogCancel,
 } from "@/components/ui/alert-dialog";
-import Image from "next/image";
 import { toast } from "sonner";
 import Bet from "../Challenge/Bet";
 import { useHeroes } from "@/lib/heroes";


### PR DESCRIPTION
Reduced size text for header on mobile screens.
Custom text for "create new challenge"/"create new character".
Added different color for mobile version.
Now the header is on the same line. 
Important to fix later: there is a button in assets that is not in figma.
closes #13 