### PR TITLE
fix: added 'custom assest' button to mobile view

### DIFF
--- a/components/Challenge/PayforCreate.tsx
+++ b/components/Challenge/PayforCreate.tsx
@@ -26,13 +26,20 @@ export default function PayforCreate() {
       <div className="flex">
       <span className="block md:hidden">New Challenge</span>
       <span className="hidden md:block">Create New Challenge</span>
-      <Image
-        src="/plus.svg"
-        alt=""
-        width={1000}
-        height={1000}
-        className="w-4 h-4 md:w-6 md:h-6"
-      />
+      <svg 
+          viewBox="0 0 24 24" 
+          fill="none" 
+          xmlns="http://www.w3.org/2000/svg"
+          className="w-4 h-4 md:w-6 md:h-6"
+          >
+          <path 
+          d="M12 5V19M5 12H19" 
+          stroke="currentColor" 
+          strokeWidth="2" 
+          strokeLinecap="round" 
+          strokeLinejoin="round"
+          />
+          </svg>
       </div>
     </Button>
   );

--- a/components/Character/ModalCustomAsset.tsx
+++ b/components/Character/ModalCustomAsset.tsx
@@ -79,9 +79,24 @@ export default function ModalCustomAsset() {
   return (
     <AlertDialog open={isOpen} onOpenChange={setIsOpen}>
       <AlertDialogTrigger asChild>
-        <Button variant="simple" className="text-white gap-3">
+        <Button variant="simple" className="pt-3.5 text-sm md:text-base text-yellow-400 md:text-white flex flex-row items-center justify-end w-full md:w-auto">
+        <div className="flex">
           <span>Add Custom Asset</span>
-          <LuPlus className="text-2xl" />
+          <svg 
+          viewBox="0 0 24 24" 
+          fill="none" 
+          xmlns="http://www.w3.org/2000/svg"
+          className="w-4 h-4 md:w-6 md:h-6"
+          >
+          <path 
+          d="M12 5V19M5 12H19" 
+          stroke="currentColor" 
+          strokeWidth="2" 
+          strokeLinecap="round" 
+          strokeLinejoin="round"
+          />
+          </svg>
+          </div>
         </Button>
       </AlertDialogTrigger>
 

--- a/components/Character/Stage.tsx
+++ b/components/Character/Stage.tsx
@@ -27,13 +27,20 @@ export default function Stage() {
                 <div className="flex">
                 <span className="block md:hidden">New Character</span>
                 <span className="hidden md:block">Create New Character</span>
-                <Image
-                  src="/plus.svg"
-                  alt=""
-                  width={1000}
-                  height={1000}
+                <svg 
+                  viewBox="0 0 24 24" 
+                  fill="none" 
+                  xmlns="http://www.w3.org/2000/svg"
                   className="w-4 h-4 md:w-6 md:h-6"
-                />
+                >
+                  <path 
+                    d="M12 5V19M5 12H19" 
+                    stroke="currentColor" 
+                    strokeWidth="2" 
+                    strokeLinecap="round" 
+                    strokeLinejoin="round"
+                  />
+                </svg>
                 </div>
               </Button>
             }


### PR DESCRIPTION
Added yellow "+" to the header.
Every header looks as figma on mobile and desktop view.
closes #19 